### PR TITLE
Fix broken h3 and href in nav image

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 <body>
     <!-- Navigation -->
     <nav class="heroSpecial">
-        <img class="logo" alt="Logo" src="/assets/logo.svg" href="#hero" />
+        <img class="logo" alt="Logo" src="/assets/logo.svg" />
         <ul>
             <li><a aria-label="My Designs" href="/design" class="link">Designs</a></li>
             <li><a aria-label="My Projects" href="#projects" class="link">Projects</a></li>
@@ -115,8 +115,8 @@
             <div class="card">
                 <h3>
                     Tempy: A CLI + GUI weather app built using python
+                </h3>
             </div>
-            </h3>
         </div>
     </div>
     <!-- SECTION: Contact me -->


### PR DESCRIPTION
Closes #39 

Changes:
 - Fixes incorrectly placed h3
 - nav image had illegal href. removed the link. TODO: Make the logo always navigate to homepage.